### PR TITLE
Refactor agent.py as single source of truth

### DIFF
--- a/cycls/agent.py
+++ b/cycls/agent.py
@@ -8,7 +8,8 @@ _DEFAULT_SYSTEM = """## Tools
 - Use `rg` or `rg --files` for searching text and files — it's faster than grep.
 - Prefer `apply_patch` for single-file edits; use scripting when more efficient.
 - Default to ASCII in file edits; only use Unicode when clearly justified.
-- Always use the text editor `view` command to read files, including images (jpg, png, gif, webp) and PDFs. Never write Python scripts to extract or parse file content — `view` handles all formats natively.
+- Always use the text editor `view` command to read files, including images (jpg, png, gif, webp) and PDFs.
+- If a file format is not supported by `view` (e.g. docx, xlsx, pptx, mp4, mp3), tell the user what the file is and propose a way to extract its content. Do not run any code until the user approves. MS Office files (docx, xlsx, pptx) are ZIP archives containing XML — `unzip` is the simplest way to extract their text.
 - Always use relative paths (e.g. `foo.py`, `src/bar.py`) with the text editor — never absolute paths.
 
 ## Workspace
@@ -192,7 +193,7 @@ def _exec_editor(inp, workspace):
 # ---- Public API ----
 
 async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-20250514",
-                max_tokens=16384, thinking=True, bash_timeout=300):
+                max_tokens=16384, thinking=True, bash_timeout=600):
     """Run one Claude agent turn. Async generator yielding streaming UI components."""
     import anthropic
 
@@ -286,6 +287,8 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                     out = f"Error: {out}"
                 if block.name == "bash":
                     yield {"type": "step_data", "data": out}
+                    if isinstance(out, str) and out.startswith("Error: Command timed out"):
+                        yield {"type": "callout", "callout": out, "style": "warning"}
                 results.append({"type": "tool_result", "tool_use_id": block.id, "content": out})
             messages.append({"role": "user", "content": results})
             if hp:

--- a/cycls/agent.py
+++ b/cycls/agent.py
@@ -1,8 +1,14 @@
+"""Agent loop — streams Claude tool-use turns with sandboxed execution."""
+
 import asyncio, base64, json, os, pathlib
 from cycls.app.state import _MEDIA_TYPES, ensure_workspace, history_path, load_history, save_history
 
+# ---- Configuration ----
+
 COMPACT_THRESHOLD = 300_000
 MAX_ATTACHMENTS = 5
+MAX_RETRIES = 3
+_RETRYABLE = ("overloaded", "rate limit", "too many requests", "429", "502", "503", "504")
 
 _DEFAULT_SYSTEM = """## Tools
 - Use `rg` or `rg --files` for searching text and files — it's faster than grep.
@@ -36,8 +42,10 @@ _UI_TOOLS = [
     }
 ]
 
+# ---- Utilities ----
+
 def _sniff_media_type(data: bytes) -> str | None:
-    """Detect media type from file magic bytes. Returns None if unrecognized."""
+    """Detect media type from magic bytes."""
     head = data[:12]
     if head[:3] == b"\xff\xd8\xff":          return "image/jpeg"
     if head[:8] == b"\x89PNG\r\n\x1a\n":    return "image/png"
@@ -46,9 +54,13 @@ def _sniff_media_type(data: bytes) -> str | None:
     if head[:4] == b"%PDF":                  return "application/pdf"
     return None
 
-# ---- Internal helpers ----
+def _is_retryable(e):
+    """Check if an exception is a transient API error worth retrying."""
+    msg = str(e).lower()
+    return any(s in msg for s in _RETRYABLE)
 
 def _prepare_prompt(context):
+    """Extract user prompt and file attachments from context."""
     ws = context.workspace
     ensure_workspace(ws)
     content = context.messages.raw[-1].get("content", "")
@@ -74,8 +86,10 @@ def _prepare_prompt(context):
         prompt += "\n\nAttached files: " + ", ".join(files)
     return ws, prompt
 
+# ---- Context management ----
 
 async def _compact(client, model, messages):
+    """Summarize conversation history to free context space."""
     response = await client.messages.create(
         model=model, max_tokens=8192,
         system=[{"type": "text", "text": (
@@ -96,7 +110,10 @@ async def _compact(client, model, messages):
         {"role": "assistant", "content": "Understood. I have the full context from our previous conversation. How can I help?"},
     ]
 
+# ---- API helpers ----
+
 def _build_tools(custom):
+    """Build the tools list for the API call."""
     tools = [
         {"type": "bash_20250124", "name": "bash"},
         {"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
@@ -106,7 +123,10 @@ def _build_tools(custom):
     tools[-1]["cache_control"] = {"type": "ephemeral"}
     return tools
 
-async def _exec_bash(command, cwd, timeout=300):
+# ---- Tool execution ----
+
+async def _exec_bash(command, cwd, timeout=600):
+    """Run a bash command in a bwrap sandbox."""
     proc = await asyncio.create_subprocess_exec(
         "bwrap",
         "--ro-bind", "/", "/",
@@ -137,6 +157,7 @@ async def _exec_bash(command, cwd, timeout=300):
     return out.strip() or "(no output)"
 
 def _exec_editor(inp, workspace):
+    """Execute a text editor command (view, str_replace, create, insert)."""
     cmd = inp["command"]
     ws = pathlib.Path(workspace).resolve()
     raw = pathlib.PurePosixPath(inp["path"])
@@ -190,6 +211,21 @@ def _exec_editor(inp, workspace):
         return f"Inserted at line {pos} in {path}"
     return f"Error: unknown command {cmd}"
 
+def _prepare_tool(block, ws, timeout):
+    """Map a tool_use block to a UI step event and execution coroutine."""
+    name, inp = block.name, block.input
+    if name == "bash":
+        step = {"type": "step", "step": f"Bash({inp.get('command', '')[:60]})"}
+        coro = _exec_bash(inp.get("command", ""), ws, timeout=timeout)
+    elif name == "str_replace_based_edit_tool":
+        verb = "Editing" if inp.get("command") in ("str_replace", "create", "insert") else "Viewing"
+        step = {"type": "step", "step": f"{verb} {inp.get('path', 'file')}"}
+        coro = asyncio.sleep(0, result=_exec_editor(inp, ws))
+    else:
+        step = {"type": "tool_call", "tool": name, "args": inp}
+        coro = asyncio.sleep(0, result=f"{name} rendered successfully")
+    return step, coro
+
 # ---- Public API ----
 
 async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-20250514",
@@ -221,9 +257,11 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
 
     total_in = total_out = cache_read = cache_create = 0
     saved_count = loaded_count
+    retries = 0
 
     while True:
         try:
+            # ---- Stream response ----
             thinking_text = ""
             search_idx, search_query = None, ""
 
@@ -251,6 +289,8 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                             search_idx = None
                 response = await stream.get_final_message()
 
+            # ---- Process response ----
+            retries = 0
             total_in += response.usage.input_tokens
             total_out += response.usage.output_tokens
             cache_read += response.usage.cache_read_input_tokens or 0
@@ -263,44 +303,44 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
             if response.stop_reason != "tool_use":
                 break
 
-            # Build step indicators + dispatch tasks, then execute in parallel
-            coros = []
-            for block in tool_blocks:
-                name, inp = block.name, block.input
-                if name == "bash":
-                    yield {"type": "step", "step": f"Bash({inp.get('command', '')[:60]})"}
-                    coros.append(_exec_bash(inp.get("command", ""), ws, timeout=bash_timeout))
-                elif name == "str_replace_based_edit_tool":
-                    verb = "Editing" if inp.get("command") in ("str_replace", "create", "insert") else "Viewing"
-                    yield {"type": "step", "step": f"{verb} {inp.get('path', 'file')}"}
-                    coros.append(asyncio.sleep(0, result=_exec_editor(inp, ws)))
-                else:
-                    yield {"type": "tool_call", "tool": name, "args": inp}
-                    coros.append(asyncio.sleep(0, result=f"{name} rendered successfully"))
+            # ---- Execute tools ----
+            prepared = [_prepare_tool(b, ws, bash_timeout) for b in tool_blocks]
+            for step, _ in prepared:
+                yield step
 
-            if len(tool_blocks) > 1:
-                print(f"[PARALLEL] Running {len(tool_blocks)} tools concurrently")
-            outputs = await asyncio.gather(*coros, return_exceptions=True)
+            outputs = await asyncio.gather(*[coro for _, coro in prepared], return_exceptions=True)
+
             results = []
             for block, out in zip(tool_blocks, outputs):
                 if isinstance(out, BaseException):
                     out = f"Error: {out}"
-                if block.name == "bash":
-                    yield {"type": "step_data", "data": out}
-                    if isinstance(out, str) and out.startswith("Error: Command timed out"):
-                        yield {"type": "callout", "callout": out, "style": "warning"}
+                if isinstance(out, str) and out.startswith("Error: Command timed out"):
+                    yield {"type": "callout", "callout": out, "style": "warning"}
                 results.append({"type": "tool_result", "tool_use_id": block.id, "content": out})
             messages.append({"role": "user", "content": results})
+
+            # ---- Save incrementally ----
             if hp:
                 save_history(hp, messages[saved_count:])
                 saved_count = len(messages)
 
         except Exception as e:
+            # Retry transient API errors with exponential backoff
+            if _is_retryable(e) and retries < MAX_RETRIES:
+                retries += 1
+                delay = 2 ** retries
+                yield {"type": "step", "step": f"Rate limited, retrying in {delay}s..."}
+                await asyncio.sleep(delay)
+                continue
+
+            # Recover from errors during tool execution
             last = messages[-1] if messages else {}
             content = last.get("content", [])
             if not isinstance(content, list):
                 yield {"type": "callout", "callout": str(e), "style": "error"}
                 break
+
+            # Assistant sent tool_use but execution failed — inject error results
             if last.get("role") == "assistant" and any(b.get("type") == "tool_use" for b in content):
                 results = [{"type": "tool_result", "tool_use_id": b["id"], "content": f"Error: {e}"}
                            for b in content if b.get("type") == "tool_use"]
@@ -309,6 +349,8 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                     save_history(hp, messages[saved_count:])
                     saved_count = len(messages)
                 continue
+
+            # API rejected tool_results (e.g. oversized PDF) — replace content with error
             if any(b.get("type") == "tool_result" and not str(b.get("content", "")).startswith("Error:")
                    for b in content):
                 for b in content:
@@ -318,9 +360,11 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                     save_history(hp, messages, mode="w")
                     saved_count = len(messages)
                 continue
+
             yield {"type": "callout", "callout": str(e), "style": "error"}
             break
 
+    # ---- Final save ----
     new_messages = messages[saved_count:]
     if hp:
         saved = False

--- a/cycls/agent.py
+++ b/cycls/agent.py
@@ -1,14 +1,23 @@
 """Agent loop — streams Claude tool-use turns with sandboxed execution."""
 
 import asyncio, base64, json, os, pathlib
-from cycls.app.state import _MEDIA_TYPES, ensure_workspace, history_path, load_history, save_history
+from cycls.app.state import ensure_workspace, history_path, load_history, save_history
 
 COMPACT_THRESHOLD = 300_000
 MAX_ATTACHMENTS = 5
 MAX_RETRIES = 3
 _RETRYABLE = ("overloaded", "rate limit", "too many requests", "429", "502", "503", "504")
 
-_DEFAULT_SYSTEM = """## Tools
+_MEDIA_TYPES = {
+    ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".png": "image/png", ".gif": "image/gif", ".webp": "image/webp",
+    ".pdf": "application/pdf",
+}
+
+_DEFAULT_SYSTEM = """You are Cycls, a general-purpose AI agent built by cycls.com that runs in the user's workspace in Cycls cloud.
+You help with coding, research, writing, analysis, system administration, and any task the user brings.
+
+## Tools
 - Use `rg` or `rg --files` for searching text and files — it's faster than grep.
 - Prefer `apply_patch` for single-file edits; use scripting when more efficient.
 - Default to ASCII in file edits; only use Unicode when clearly justified.
@@ -23,6 +32,20 @@ _DEFAULT_SYSTEM = """## Tools
 - Git is not available in this workspace.
 - You are already in `/workspace` — never prefix commands with `cd /workspace`.
 - Avoid destructive commands (`rm -rf`) unless the user explicitly asks.
+
+## Working style
+- The user may not be technical. Never assume they know programming concepts, terminal commands, or file system conventions.
+- Present results in plain language. Instead of dumping raw command output, summarize what you found or did.
+
+## Research and analysis
+- When asked to research a topic, search the web and synthesize findings.
+- Present findings organized by relevance, with sources.
+- Distinguish facts from opinions and flag uncertainty.
+
+## Code review
+- Prioritize bugs, security risks, and missing tests.
+- Present findings by severity with file and line references.
+- State explicitly if no issues are found.
 """
 
 _UI_TOOLS = [
@@ -93,13 +116,16 @@ async def _compact(client, model, messages):
         {"role": "assistant", "content": "Understood. I have the full context from our previous conversation. How can I help?"},
     ]
 
-def _build_tools(custom):
-    tools = [
-        {"type": "bash_20250124", "name": "bash"},
-        {"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
-        {"type": "web_search_20250305", "name": "web_search"},
-    ] + [{"type": "custom", "name": t["name"], "description": t.get("description", ""),
-          "input_schema": t.get("inputSchema", t.get("input_schema", {}))} for t in custom or []]
+_BUILTINS = {
+    "Bash": {"type": "bash_20250124", "name": "bash"},
+    "Editor": {"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
+    "WebSearch": {"type": "web_search_20250305", "name": "web_search"},
+}
+
+def _build_tools(builtin_tools, custom):
+    tools = [_BUILTINS[b] for b in builtin_tools]
+    tools += [{"type": "custom", "name": t["name"], "description": t.get("description", ""),
+               "input_schema": t.get("inputSchema", t.get("input_schema", {}))} for t in custom or []]
     tools[-1] = {**tools[-1], "cache_control": {"type": "ephemeral"}}
     return tools
 
@@ -187,15 +213,43 @@ def _exec_editor(inp, workspace):
 
 async def _defer(fn, *args): return fn(*args)
 
+_UI_TOOL_NAMES = {t["name"] for t in _UI_TOOLS}
+
+def _render_ui_tool(name, args):
+    if name == "render_table":
+        events = []
+        if title := args.get("title"):
+            events.append(f"\n**{title}**\n")
+        events.append({"type": "table", "headers": args.get("headers", [])})
+        for row in args.get("rows", []):
+            events.append({"type": "table", "row": row})
+        return events
+    if name == "render_callout":
+        return [{"type": "callout", "callout": args.get("message", ""), "style": args.get("style", "info"), "title": args.get("title", "")}]
+    if name == "render_image":
+        return [{"type": "image", "src": args.get("src", ""), "alt": args.get("alt", ""), "caption": args.get("caption", "")}]
+    if name == "render_canvas":
+        return [
+            {"type": "canvas", "canvas": "document", "open": True, "title": args.get("title", "Document")},
+            {"type": "canvas", "canvas": "document", "content": args.get("content", "")},
+            {"type": "canvas", "canvas": "document", "done": True},
+        ]
+    return None
+
 def _prepare_tool(block, ws, timeout):
     name, inp = block.name, block.input
     if name == "bash":
-        step = {"type": "step", "step": f"Bash({inp.get('command', '')[:60]})"}
+        cmd = inp.get('command', '')
+        label = cmd if len(cmd) <= 80 else cmd[:60] + ' … ' + cmd[-17:]
+        step = {"type": "step", "step": f"Bash({label})"}
         coro = _exec_bash(inp.get("command", ""), ws, timeout=timeout)
     elif name == "str_replace_based_edit_tool":
         verb = "Editing" if inp.get("command") in ("str_replace", "create", "insert") else "Viewing"
         step = {"type": "step", "step": f"{verb} {inp.get('path', 'file')}"}
         coro = _defer(_exec_editor, inp, ws)
+    elif name in _UI_TOOL_NAMES:
+        step = _render_ui_tool(name, inp) or []
+        coro = asyncio.sleep(0, result=f"{name} rendered successfully")
     else:
         step = {"type": "tool_call", "tool": name, "args": inp}
         coro = asyncio.sleep(0, result=f"{name} rendered successfully")
@@ -222,8 +276,7 @@ def _recover(e, messages):
         return "w"
     return None
 
-async def _finalize(client, model, hp, messages, saved, usage):
-    """Compact if needed, save remaining history, emit usage."""
+async def _finalize(client, model, hp, messages, saved, usage, show_usage=False):
     new = messages[saved:]
     if hp:
         did_compact = False
@@ -237,11 +290,12 @@ async def _finalize(client, model, hp, messages, saved, usage):
                 pass
         if not did_compact and new and new[-1].get("role") == "assistant":
             save_history(hp, new)
-    if usage["inputTokens"]:
-        yield {"type": "usage", "usage": {"tokenUsage": {"total": usage}}}
+    if show_usage and usage["inputTokens"]:
+        yield f'\n\n*in: {usage["inputTokens"]:,} · out: {usage["outputTokens"]:,} · cached: {usage["cachedInputTokens"]:,} · cache-create: {usage["cacheCreationTokens"]:,}*'
 
-async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-20250514",
-                max_tokens=16384, thinking=True, bash_timeout=600):
+async def Agent(*, context, system="", tools=None, builtin_tools=[],
+                model="claude-sonnet-4-20250514", max_tokens=16384, thinking=True,
+                bash_timeout=600, show_usage=False):
     """Run one Claude agent turn. Async generator yielding streaming UI components."""
     import anthropic
 
@@ -256,7 +310,7 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
 
     kwargs = {
         "model": model, "max_tokens": max_tokens,
-        "tools": _build_tools(_UI_TOOLS + (tools or [])),
+        "tools": _build_tools(builtin_tools, _UI_TOOLS + (tools or [])),
         "messages": messages,
         "system": [{"type": "text", "text": _DEFAULT_SYSTEM + ("\n\n" + system if system else ""),
                      "cache_control": {"type": "ephemeral"}}],
@@ -311,7 +365,11 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
             # ---- Execute tools ----
             tool_blocks = [b for b in response.content if b.type == "tool_use"]
             steps, coros = zip(*(_prepare_tool(b, ws, bash_timeout) for b in tool_blocks))
-            for s in steps: yield s
+            for s in steps:
+                if isinstance(s, list):
+                    for e in s: yield e
+                else:
+                    yield s
             outputs = await asyncio.gather(*coros, return_exceptions=True)
 
             results = []
@@ -342,5 +400,5 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                 saved = len(messages)
             continue
 
-    async for event in _finalize(client, model, hp, messages, saved, usage):
+    async for event in _finalize(client, model, hp, messages, saved, usage, show_usage):
         yield event

--- a/cycls/agent.py
+++ b/cycls/agent.py
@@ -3,8 +3,6 @@
 import asyncio, base64, json, os, pathlib
 from cycls.app.state import _MEDIA_TYPES, ensure_workspace, history_path, load_history, save_history
 
-# ---- Configuration ----
-
 COMPACT_THRESHOLD = 300_000
 MAX_ATTACHMENTS = 5
 MAX_RETRIES = 3
@@ -42,10 +40,7 @@ _UI_TOOLS = [
     }
 ]
 
-# ---- Utilities ----
-
 def _sniff_media_type(data: bytes) -> str | None:
-    """Detect media type from magic bytes."""
     head = data[:12]
     if head[:3] == b"\xff\xd8\xff":          return "image/jpeg"
     if head[:8] == b"\x89PNG\r\n\x1a\n":    return "image/png"
@@ -55,17 +50,13 @@ def _sniff_media_type(data: bytes) -> str | None:
     return None
 
 def _is_retryable(e):
-    """Check if an exception is a transient API error worth retrying."""
     msg = str(e).lower()
     return any(s in msg for s in _RETRYABLE)
 
 def _prepare_prompt(context):
-    """Extract user prompt and file attachments from context."""
-    ws = context.workspace
-    ensure_workspace(ws)
     content = context.messages.raw[-1].get("content", "")
     if not isinstance(content, list):
-        return ws, content
+        return content
     texts = []
     files = []
     for p in content:
@@ -84,12 +75,9 @@ def _prepare_prompt(context):
     prompt = " ".join(texts)
     if files:
         prompt += "\n\nAttached files: " + ", ".join(files)
-    return ws, prompt
-
-# ---- Context management ----
+    return prompt
 
 async def _compact(client, model, messages):
-    """Summarize conversation history to free context space."""
     response = await client.messages.create(
         model=model, max_tokens=8192,
         system=[{"type": "text", "text": (
@@ -100,33 +88,24 @@ async def _compact(client, model, messages):
         )}],
         messages=messages + [{"role": "user", "content": "Summarize our conversation so far for continuity."}],
     )
-    summary = response.content[0].text
     return [
-        {"role": "user", "content": (
-            "This session is being continued from a previous conversation "
-            "that ran out of context. The conversation is summarized below:\n\n"
-            + summary
-        )},
+        {"role": "user", "content": "This session is being continued from a previous conversation that ran out of context. The conversation is summarized below:\n\n" + response.content[0].text},
         {"role": "assistant", "content": "Understood. I have the full context from our previous conversation. How can I help?"},
     ]
 
-# ---- API helpers ----
-
 def _build_tools(custom):
-    """Build the tools list for the API call."""
     tools = [
         {"type": "bash_20250124", "name": "bash"},
         {"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
         {"type": "web_search_20250305", "name": "web_search"},
     ] + [{"type": "custom", "name": t["name"], "description": t.get("description", ""),
           "input_schema": t.get("inputSchema", t.get("input_schema", {}))} for t in custom or []]
-    tools[-1]["cache_control"] = {"type": "ephemeral"}
+    tools[-1] = {**tools[-1], "cache_control": {"type": "ephemeral"}}
     return tools
 
 # ---- Tool execution ----
 
 async def _exec_bash(command, cwd, timeout=600):
-    """Run a bash command in a bwrap sandbox."""
     proc = await asyncio.create_subprocess_exec(
         "bwrap",
         "--ro-bind", "/", "/",
@@ -157,35 +136,30 @@ async def _exec_bash(command, cwd, timeout=600):
     return out.strip() or "(no output)"
 
 def _exec_editor(inp, workspace):
-    """Execute a text editor command (view, str_replace, create, insert)."""
     cmd = inp["command"]
     ws = pathlib.Path(workspace).resolve()
     raw = pathlib.PurePosixPath(inp["path"])
-    # Strip /workspace prefix (bwrap mount point) or leading / so all paths resolve under ws
     try:
         rel = raw.relative_to("/workspace")
     except ValueError:
         rel = pathlib.PurePosixPath(raw.as_posix().lstrip("/"))
     path = (ws / rel).resolve()
     if not path.is_relative_to(ws):
-        return f"Error: path escapes workspace"
+        return "Error: path escapes workspace"
     if cmd != "create" and not path.exists():
         return f"Error: {path} does not exist"
     if path.is_dir():
         return f"Error: {path} is a directory, not a file"
     if cmd == "view":
-        ext = path.suffix.lower()
-        media_type = _MEDIA_TYPES.get(ext)
+        media_type = _MEDIA_TYPES.get(path.suffix.lower())
         if media_type:
-            raw = path.read_bytes()
-            media_type = _sniff_media_type(raw) or media_type
-            data = base64.b64encode(raw).decode()
+            blob = path.read_bytes()
+            media_type = _sniff_media_type(blob) or media_type
+            data = base64.b64encode(blob).decode()
             kind = "document" if not media_type.startswith("image/") else "image"
             return [{"type": kind, "source": {"type": "base64", "media_type": media_type, "data": data}}]
-        try:
-            lines = path.read_text().splitlines()
-        except UnicodeDecodeError:
-            return f"Error: {path} is a binary file"
+        try: lines = path.read_text().splitlines()
+        except UnicodeDecodeError: return f"Error: {path} is a binary file"
         vr = inp.get("view_range")
         start = vr[0] if vr else 1
         if vr: lines = lines[vr[0] - 1:vr[1]]
@@ -211,8 +185,9 @@ def _exec_editor(inp, workspace):
         return f"Inserted at line {pos} in {path}"
     return f"Error: unknown command {cmd}"
 
+async def _defer(fn, *args): return fn(*args)
+
 def _prepare_tool(block, ws, timeout):
-    """Map a tool_use block to a UI step event and execution coroutine."""
     name, inp = block.name, block.input
     if name == "bash":
         step = {"type": "step", "step": f"Bash({inp.get('command', '')[:60]})"}
@@ -220,51 +195,81 @@ def _prepare_tool(block, ws, timeout):
     elif name == "str_replace_based_edit_tool":
         verb = "Editing" if inp.get("command") in ("str_replace", "create", "insert") else "Viewing"
         step = {"type": "step", "step": f"{verb} {inp.get('path', 'file')}"}
-        coro = asyncio.sleep(0, result=_exec_editor(inp, ws))
+        coro = _defer(_exec_editor, inp, ws)
     else:
         step = {"type": "tool_call", "tool": name, "args": inp}
         coro = asyncio.sleep(0, result=f"{name} rendered successfully")
     return step, coro
 
-# ---- Public API ----
+# ---- Agent ----
+
+def _recover(e, messages):
+    """Try to patch messages for recovery. Returns save mode ("a"/"w") or None."""
+    last = messages[-1] if messages else {}
+    content = last.get("content", [])
+    if not isinstance(content, list):
+        return None
+    if last.get("role") == "assistant" and any(b.get("type") == "tool_use" for b in content):
+        results = [{"type": "tool_result", "tool_use_id": b["id"], "content": f"Error: {e}"}
+                   for b in content if b.get("type") == "tool_use"]
+        messages.append({"role": "user", "content": results})
+        return "a"
+    if any(b.get("type") == "tool_result" and not str(b.get("content", "")).startswith("Error:")
+           for b in content):
+        for b in content:
+            if b.get("type") == "tool_result":
+                b["content"] = f"Error: {e}"
+        return "w"
+    return None
+
+async def _finalize(client, model, hp, messages, saved, usage):
+    """Compact if needed, save remaining history, emit usage."""
+    new = messages[saved:]
+    if hp:
+        did_compact = False
+        if usage["inputTokens"] > COMPACT_THRESHOLD and messages:
+            try:
+                yield {"type": "step", "step": "Compacting context..."}
+                summary = await _compact(client, model, messages)
+                save_history(hp, summary, mode="w")
+                did_compact = True
+            except Exception:
+                pass
+        if not did_compact and new and new[-1].get("role") == "assistant":
+            save_history(hp, new)
+    if usage["inputTokens"]:
+        yield {"type": "usage", "usage": {"tokenUsage": {"total": usage}}}
 
 async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-20250514",
                 max_tokens=16384, thinking=True, bash_timeout=600):
     """Run one Claude agent turn. Async generator yielding streaming UI components."""
     import anthropic
 
-    ws, prompt = _prepare_prompt(context)
+    ws = context.workspace
+    ensure_workspace(ws)
+    prompt = _prepare_prompt(context)
     client = anthropic.AsyncAnthropic()
-
-    sid = context.session_id
-    user = context.user
-    hp = history_path(user, sid) if sid and user else None
-
+    hp = history_path(context.user, context.session_id) if context.session_id and context.user else None
     messages = load_history(hp) if hp else []
-    loaded_count = len(messages)
+    saved = len(messages)
     messages.append({"role": "user", "content": prompt})
-
-    all_tools = _UI_TOOLS + (tools or [])
-    full_system = _DEFAULT_SYSTEM + ("\n\n" + system if system else "")
 
     kwargs = {
         "model": model, "max_tokens": max_tokens,
-        "tools": _build_tools(all_tools), "messages": messages,
-        "system": [{"type": "text", "text": full_system, "cache_control": {"type": "ephemeral"}}],
+        "tools": _build_tools(_UI_TOOLS + (tools or [])),
+        "messages": messages,
+        "system": [{"type": "text", "text": _DEFAULT_SYSTEM + ("\n\n" + system if system else ""),
+                     "cache_control": {"type": "ephemeral"}}],
+        **({"thinking": {"type": "adaptive"}} if thinking else {}),
     }
-    if thinking:
-        kwargs["thinking"] = {"type": "adaptive"}
 
-    total_in = total_out = cache_read = cache_create = 0
-    saved_count = loaded_count
+    usage = {"inputTokens": 0, "outputTokens": 0, "cachedInputTokens": 0, "cacheCreationTokens": 0}
     retries = 0
 
     while True:
         try:
-            # ---- Stream response ----
-            thinking_text = ""
-            search_idx, search_query = None, ""
-
+            # ---- Stream ----
+            thinking_text, search_idx, search_query = "", None, ""
             async with client.messages.stream(**kwargs) as stream:
                 async for ev in stream:
                     if ev.type == "content_block_start":
@@ -289,97 +294,53 @@ async def Agent(*, context, system="", tools=None, model="claude-sonnet-4-202505
                             search_idx = None
                 response = await stream.get_final_message()
 
-            # ---- Process response ----
+            # ---- Process ----
             retries = 0
-            total_in += response.usage.input_tokens
-            total_out += response.usage.output_tokens
-            cache_read += response.usage.cache_read_input_tokens or 0
-            cache_create += response.usage.cache_creation_input_tokens or 0
+            u = response.usage
+            usage["inputTokens"] += u.input_tokens
+            usage["outputTokens"] += u.output_tokens
+            usage["cachedInputTokens"] += u.cache_read_input_tokens or 0
+            usage["cacheCreationTokens"] += u.cache_creation_input_tokens or 0
 
-            content = [b.model_dump(exclude_none=True) for b in response.content]
-            messages.append({"role": "assistant", "content": content})
-            tool_blocks = [b for b in response.content if b.type == "tool_use"]
+            messages.append({"role": "assistant",
+                            "content": [b.model_dump(exclude_none=True) for b in response.content]})
 
             if response.stop_reason != "tool_use":
                 break
 
             # ---- Execute tools ----
-            prepared = [_prepare_tool(b, ws, bash_timeout) for b in tool_blocks]
-            for step, _ in prepared:
-                yield step
-
-            outputs = await asyncio.gather(*[coro for _, coro in prepared], return_exceptions=True)
+            tool_blocks = [b for b in response.content if b.type == "tool_use"]
+            steps, coros = zip(*(_prepare_tool(b, ws, bash_timeout) for b in tool_blocks))
+            for s in steps: yield s
+            outputs = await asyncio.gather(*coros, return_exceptions=True)
 
             results = []
             for block, out in zip(tool_blocks, outputs):
-                if isinstance(out, BaseException):
-                    out = f"Error: {out}"
+                if isinstance(out, BaseException): out = f"Error: {out}"
                 if isinstance(out, str) and out.startswith("Error: Command timed out"):
                     yield {"type": "callout", "callout": out, "style": "warning"}
                 results.append({"type": "tool_result", "tool_use_id": block.id, "content": out})
             messages.append({"role": "user", "content": results})
 
-            # ---- Save incrementally ----
             if hp:
-                save_history(hp, messages[saved_count:])
-                saved_count = len(messages)
+                save_history(hp, messages[saved:])
+                saved = len(messages)
 
         except Exception as e:
-            # Retry transient API errors with exponential backoff
             if _is_retryable(e) and retries < MAX_RETRIES:
                 retries += 1
                 delay = 2 ** retries
                 yield {"type": "step", "step": f"Rate limited, retrying in {delay}s..."}
                 await asyncio.sleep(delay)
                 continue
-
-            # Recover from errors during tool execution
-            last = messages[-1] if messages else {}
-            content = last.get("content", [])
-            if not isinstance(content, list):
+            mode = _recover(e, messages)
+            if mode is None:
                 yield {"type": "callout", "callout": str(e), "style": "error"}
                 break
+            if hp:
+                save_history(hp, messages if mode == "w" else messages[saved:], mode=mode)
+                saved = len(messages)
+            continue
 
-            # Assistant sent tool_use but execution failed — inject error results
-            if last.get("role") == "assistant" and any(b.get("type") == "tool_use" for b in content):
-                results = [{"type": "tool_result", "tool_use_id": b["id"], "content": f"Error: {e}"}
-                           for b in content if b.get("type") == "tool_use"]
-                messages.append({"role": "user", "content": results})
-                if hp:
-                    save_history(hp, messages[saved_count:])
-                    saved_count = len(messages)
-                continue
-
-            # API rejected tool_results (e.g. oversized PDF) — replace content with error
-            if any(b.get("type") == "tool_result" and not str(b.get("content", "")).startswith("Error:")
-                   for b in content):
-                for b in content:
-                    if b.get("type") == "tool_result":
-                        b["content"] = f"Error: {e}"
-                if hp:
-                    save_history(hp, messages, mode="w")
-                    saved_count = len(messages)
-                continue
-
-            yield {"type": "callout", "callout": str(e), "style": "error"}
-            break
-
-    # ---- Final save ----
-    new_messages = messages[saved_count:]
-    if hp:
-        saved = False
-        if total_in > COMPACT_THRESHOLD and messages:
-            try:
-                yield {"type": "step", "step": "Compacting context..."}
-                messages = await _compact(client, model, messages)
-                save_history(hp, messages, mode="w")
-                saved = True
-            except Exception:
-                pass
-        if not saved and new_messages and new_messages[-1].get("role") == "assistant":
-            save_history(hp, new_messages)
-    if total_in:
-        yield {"type": "usage", "usage": {"tokenUsage": {"total": {
-            "inputTokens": total_in, "outputTokens": total_out,
-            "cachedInputTokens": cache_read, "cacheCreationTokens": cache_create,
-        }}}}
+    async for event in _finalize(client, model, hp, messages, saved, usage):
+        yield event

--- a/cycls/app/state.py
+++ b/cycls/app/state.py
@@ -6,12 +6,6 @@ from typing import Any
 from fastapi import APIRouter, Request, HTTPException, UploadFile, File
 from fastapi.responses import FileResponse
 
-_MEDIA_TYPES = {
-    ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
-    ".png": "image/png", ".gif": "image/gif", ".webp": "image/webp",
-    ".pdf": "application/pdf",
-}
-
 def resolve_path(workspace, rel):
     """Resolve *rel* inside *workspace*, raising ValueError on traversal."""
     workspace = Path(workspace)
@@ -19,23 +13,6 @@ def resolve_path(workspace, rel):
     if not resolved.is_relative_to(workspace.resolve()):
         raise ValueError("Path traversal denied")
     return resolved
-
-def read_file(workspace, filename):
-    """Read a workspace file safely. Returns (media_type, bytes) for binary
-    media files, or (None, str) for text files. Raises ValueError on
-    traversal and FileNotFoundError when the file doesn't exist."""
-    path = resolve_path(workspace, filename)
-    if not path.is_file():
-        raise FileNotFoundError(f"{filename} not found")
-    ext = path.suffix.lower()
-    media_type = _MEDIA_TYPES.get(ext)
-    if media_type:
-        return media_type, path.read_bytes()
-    try:
-        text = path.read_text()
-    except UnicodeDecodeError:
-        raise UnicodeDecodeError("utf-8", b"", 0, 1, f"{filename} is a binary file")
-    return None, text
 
 def ensure_workspace(workspace):
     """Create the workspace directory tree if it doesn't exist."""

--- a/examples/agent/super.py
+++ b/examples/agent/super.py
@@ -98,5 +98,5 @@ async def super(context):
             yield msg
 
 
-# super.local()
-super.deploy()
+super.local()
+# super.deploy()

--- a/examples/agent/super.py
+++ b/examples/agent/super.py
@@ -23,17 +23,23 @@ TOOLS = [
 ]
 
 
-@cycls.app(auth=True, analytics=True, copy=[".env"], force_rebuild=False)
+@cycls.app(
+    auth=True, 
+    analytics=True, 
+    copy=[".env"], 
+    force_rebuild=False # app_options ["Auth", "Analytics"]
+) 
 async def super(context):
-    print("context.messages.raw:", context.messages.raw)
-    async for msg in cycls.Agent(context=context,
-                                 system=SYSTEM, 
-                                 tools=TOOLS, 
-                                 builtin_tools=["Bash", "Editor", "WebSearch"],
-                                 model="claude-sonnet-4-6",
-                                 show_usage=True):
+    async for msg in cycls.Agent(
+                                context=context,
+                                system=SYSTEM, 
+                                tools=TOOLS, # skills+safe_keys
+                                builtin_tools=["Bash", "Editor", "WebSearch"],
+                                model="claude-sonnet-4-6",
+                                show_usage=False
+                            ):
         yield msg
 
 
-super.local()
-# super.deploy()
+# super.local()
+super.deploy()

--- a/examples/agent/super.py
+++ b/examples/agent/super.py
@@ -25,9 +25,9 @@ TOOLS = [
 
 @cycls.app(
     auth=True, 
-    analytics=True, 
+    analytics=True, # web=["Auth", "Analytics"]
     copy=[".env"], 
-    force_rebuild=False # app_options ["Auth", "Analytics"]
+    force_rebuild=False
 ) 
 async def super(context):
     async for msg in cycls.Agent(

--- a/examples/agent/super.py
+++ b/examples/agent/super.py
@@ -1,53 +1,12 @@
 # uv run examples/agent/super.py
-# echo '+\!10' | k 🤯
 import cycls
 
 SYSTEM = """
-You are Cycls, a general-purpose AI agent built by cycls.com that runs in the user's workspace in Cycls cloud.
-You help with coding, research, writing, analysis, system administration, and any task the user brings.
-
-## Working style
-- The user may not be technical. Never assume they know programming concepts, terminal commands, or file system conventions.
-- Present results in plain language. Instead of dumping raw command output, summarize what you found or did.
-
-## Research and analysis
-- When asked to research a topic, search the web and synthesize findings.
-- Present findings organized by relevance, with sources.
-- Distinguish facts from opinions and flag uncertainty.
-
-## Code review
-- Prioritize bugs, security risks, and missing tests.
-- Present findings by severity with file and line references.
-- State explicitly if no issues are found.
+You are Cycls.
 """.strip()
 
+
 TOOLS = [
-    {
-        "name": "render_table",
-        "description": "Display a data table to the user. Use for structured data, comparisons, listings.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "title": {"type": "string", "description": "Optional table title"},
-                "headers": {"type": "array", "items": {"type": "string"}},
-                "rows": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}}
-            },
-            "required": ["headers", "rows"]
-        }
-    },
-    {
-        "name": "render_callout",
-        "description": "Display a callout/alert box. Use for warnings, tips, success messages, errors.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "message": {"type": "string"},
-                "style": {"type": "string", "enum": ["info", "warning", "error", "success"]},
-                "title": {"type": "string"}
-            },
-            "required": ["message", "style"]
-        }
-    },
     {
         "name": "render_image",
         "description": "Display an image to the user.",
@@ -66,36 +25,14 @@ TOOLS = [
 
 @cycls.app(auth=True, analytics=True, copy=[".env"], force_rebuild=False)
 async def super(context):
+    print("context.messages.raw:", context.messages.raw)
     async for msg in cycls.Agent(context=context,
-                                system=SYSTEM,
-                                tools=TOOLS,
-                                model="claude-sonnet-4-6", bash_timeout=10):
-        if not isinstance(msg, dict):
-            yield msg
-            continue
-        t = msg.get("type")
-        if t == "tool_call":
-            tool, args = msg["tool"], msg["args"]
-            if tool == "render_table":
-                if title := args.get("title"):
-                    yield f"\n**{title}**\n"
-                yield {"type": "table", "headers": args.get("headers", [])}
-                for row in args.get("rows", []):
-                    yield {"type": "table", "row": row}
-            elif tool == "render_callout":
-                yield {"type": "callout", "callout": args.get("message", ""), "style": args.get("style", "info"), "title": args.get("title", "")}
-            elif tool == "render_image":
-                src = args.get("src", "")
-                yield {"type": "image", "src": src, "alt": args.get("alt", ""), "caption": args.get("caption", "")}
-            elif tool == "render_canvas":
-                yield {"type": "canvas", "canvas": "document", "open": True, "title": args.get("title", "Document")}
-                yield {"type": "canvas", "canvas": "document", "content": args.get("content", "")}
-                yield {"type": "canvas", "canvas": "document", "done": True}
-        # elif t == "usage":
-        #     u = msg["usage"].get("tokenUsage", {}).get("total", {})
-        #     yield f'\n\n*in: {u.get("inputTokens", 0):,} · out: {u.get("outputTokens", 0):,} · cached: {u.get("cachedInputTokens", 0):,} · cache-create: {u.get("cacheCreationTokens", 0):,}*'
-        else:
-            yield msg
+                                 system=SYSTEM, 
+                                 tools=TOOLS, 
+                                 builtin_tools=["Bash", "Editor", "WebSearch"],
+                                 model="claude-sonnet-4-6",
+                                 show_usage=True):
+        yield msg
 
 
 super.local()

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -465,7 +465,7 @@ def test_prepare_prompt_under_limit(tmp_path):
     ctx.messages = types.SimpleNamespace()
     ctx.messages.raw = [{"role": "user", "content": parts}]
 
-    _, prompt = _prepare_prompt(ctx)
+    prompt = _prepare_prompt(ctx)
     for i in range(MAX_ATTACHMENTS):
         assert f"doc{i}.pdf" in prompt
     assert "not loaded" not in prompt
@@ -483,7 +483,7 @@ def test_prepare_prompt_over_limit(tmp_path):
     ctx.messages = types.SimpleNamespace()
     ctx.messages.raw = [{"role": "user", "content": parts}]
 
-    _, prompt = _prepare_prompt(ctx)
+    prompt = _prepare_prompt(ctx)
     # First MAX_ATTACHMENTS are in the attached files list
     for i in range(MAX_ATTACHMENTS):
         assert f"img{i}.png" in prompt

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cycls.agent import Agent, COMPACT_THRESHOLD, MAX_ATTACHMENTS, _exec_bash, _exec_editor, _prepare_prompt, _sniff_media_type
+from cycls.agent import Agent, COMPACT_THRESHOLD, MAX_ATTACHMENTS, MAX_RETRIES, _exec_bash, _exec_editor, _is_retryable, _prepare_prompt, _prepare_tool, _sniff_media_type
 from cycls.app.state import load_history
 
 
@@ -615,6 +615,63 @@ def test_exec_bash_truncates_large_output(tmp_path):
     result = asyncio.run(run())
     assert len(result) < 25000
     assert "truncated" in result
+
+
+# ---------------------------------------------------------------------------
+# Auto-retry tests
+# ---------------------------------------------------------------------------
+
+def test_is_retryable_detects_transient_errors():
+    assert _is_retryable(Exception("overloaded"))
+    assert _is_retryable(Exception("rate limit exceeded"))
+    assert _is_retryable(Exception("429 Too Many Requests"))
+    assert _is_retryable(Exception("502 Bad Gateway"))
+    assert not _is_retryable(Exception("invalid api key"))
+    assert not _is_retryable(Exception("context too long"))
+
+
+def test_auto_retry_on_overloaded(agent_env):
+    """Transient API errors should be retried, not shown as errors."""
+    ws, hp, ctx = agent_env
+
+    call_count = 0
+    final = _make_response([_text_block("Done")])
+
+    def stream_side_effect(**kw):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise Exception("overloaded")
+        return FakeStream(final)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = stream_side_effect
+
+    with _mock_anthropic(mock_client), \
+         patch("asyncio.sleep", new_callable=lambda: AsyncMock(return_value=None)):
+        items = asyncio.run(_drain(Agent(context=ctx, thinking=False)))
+
+    # No error callouts — retries handled it
+    callouts = [i for i in items if isinstance(i, dict) and i.get("type") == "callout"]
+    assert not callouts
+    # Should have retried and succeeded
+    assert call_count == 3
+
+
+def test_auto_retry_exhausted_shows_error(agent_env):
+    """After MAX_RETRIES, the error should surface to the user."""
+    ws, hp, ctx = agent_env
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(side_effect=Exception("overloaded"))
+
+    with _mock_anthropic(mock_client), \
+         patch("asyncio.sleep", new_callable=lambda: AsyncMock(return_value=None)):
+        items = asyncio.run(_drain(Agent(context=ctx, thinking=False)))
+
+    callouts = [i for i in items if isinstance(i, dict) and i.get("type") == "callout"]
+    assert len(callouts) == 1
+    assert "overloaded" in callouts[0]["callout"]
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "cycls"
-version = "0.0.2.116"
+version = "0.0.2.117"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
## Summary
- **Agent loop improvements**: auto-retry on transient errors, cleaner structure, extract `_recover`/`_finalize` helpers
- **Absorb UI tools**: move render_table, render_callout, render_image, render_canvas schemas and rendering into agent.py — consumers just `yield msg`
- **Configurable builtins**: `builtin_tools=["Bash", "Editor", "WebSearch"]` parameter to opt in/out of built-in tools
- **Move `_MEDIA_TYPES`** and `read_file` out of state.py into agent.py
- **Expand default system prompt** with working style, research, and code review sections
- **`show_usage` flag**: opt-in formatted token usage output
- **Smarter bash labels**: show head+tail for long commands to avoid identical-looking truncated steps
- **Simplify super.py** from ~100 lines to ~15

## Test plan
- [x] All 23 agent tests pass
- [x] Live tested with super.py (bash steps, canvas, usage display)