### PR TITLE
fix(sandbox): restore bash on the gVisor runtime (openat2 + trash mountpoints)

### DIFF
--- a/cycls/_agent/tools/__init__.py
+++ b/cycls/_agent/tools/__init__.py
@@ -386,6 +386,19 @@ async def _exec_bash(command, cwd, timeout=600, network=False):
     # `rm`/`rmdir` move to the trash instead of unlinking.
     trash_dir = os.path.join(cwd, trash.DIR)
     os.makedirs(trash_dir, exist_ok=True)
+    # bwrap can't create bind mount points inside its read-only root (`--ro-bind /
+    # /`), so every top-level bind target must already exist on the real fs. The
+    # dev-skill mounts below are guarded by `os.path.isdir`; /workspace comes from
+    # the volume mount; but /workspace-trash and /opt/cycls-bin are always bound and
+    # nothing else creates them — so bwrap dies with "Can't mkdir /workspace-trash:
+    # Read-only file system". Pre-create them here (cf. skills.configure, which does
+    # the same for /skills/<name>). Best-effort: a read-only container root would
+    # only cost the bash tool, not crash the agent.
+    for _mnt in ("/workspace-trash", "/opt/cycls-bin"):
+        try:
+            os.makedirs(_mnt, exist_ok=True)
+        except OSError:
+            pass
     shims = str(pathlib.Path(__file__).parent / "shims")
     env = {"PATH": f"/opt/cycls-bin:{path}", "LANG": lang,
            "CYCLS_WORKSPACE": "/workspace", "CYCLS_TRASH": "/workspace-trash"}

--- a/cycls/_function/main.py
+++ b/cycls/_function/main.py
@@ -102,7 +102,14 @@ class Function:
                 "functions ship as cloudpickle bytecode, which only loads on the same "
                 "major.minor Python.")
         self.python_version = python_version or host_py
-        self.base_image = f"python:{self.python_version}-slim"
+        # Pin Debian 12 "bookworm". The default `-slim` tag has moved to Debian 13
+        # "trixie", which ships bubblewrap 0.12 — it opens every bind-mount source
+        # via openat2(2), a syscall the gVisor-based deploy runtime doesn't implement
+        # (ENOSYS). That breaks the bash sandbox entirely: every `bash` call dies with
+        # "Can't open source /: Function not implemented". bookworm's bubblewrap 0.8
+        # uses classic open()+mount(), which the runtime supports. Revisit once the
+        # runtime implements openat2 or bwrap no longer requires it.
+        self.base_image = f"python:{self.python_version}-slim-bookworm"
         self.apt = sorted([*self._base_apt, *image.get("apt", [])])
         self.run_commands = list(image.get("run_commands", []))
         self.copy = image.get("copy", {})


### PR DESCRIPTION
## Problem

After the `feat/canvas-viewer` rollout, the agent **bash tool was 100% non-functional** on the `me-central2` runtime — every `bash` call failed instantly, and (worse) the failure was returned as normal tool output so it logged as `ok:true` and never showed in failure metrics. Two stacked bugs:

### 1. `openat2(2)` returns ENOSYS on the gVisor runtime
The default `python:*-slim` base tag has drifted to Debian 13 "trixie", which ships **bubblewrap 0.12**. bwrap 0.12 opens every bind-mount source via `openat2(2)` — a syscall the gVisor-based deploy runtime doesn't implement (`ENOSYS`). bwrap died at `Can't open source /: Function not implemented` before running anything.

**Fix:** pin the base image to `-slim-bookworm` (Debian 12, bubblewrap 0.8, classic `open()` + `mount()`, which the runtime supports). — `cycls/_function/main.py`

### 2. Read-only `mkdir /workspace-trash`
Once bwrap started, it failed at `Can't mkdir /workspace-trash: Read-only file system`. bwrap can't create bind mount points inside its read-only root (`--ro-bind / /`); the trash feature binds `trash_dir → /workspace-trash` and the shims `→ /opt/cycls-bin`, but nothing pre-created those mountpoints (unlike `/skills` via `skills.configure`, or `/workspace` from the volume mount).

**Fix:** pre-create `/workspace-trash` and `/opt/cycls-bin` on the real fs in `_exec_bash`, best-effort, matching the existing `skills.configure` pattern. — `cycls/_agent/tools/__init__.py`

## Validation

Both verified on `me-central2` by deploying a throwaway function that replicates the exact `network=True` sandbox invocation directly against the runtime:

- **Before:** `Can't open source /: Function not implemented`, and after fix #1, `Can't mkdir /workspace-trash: Read-only file system`.
- **After:** bash runs — `echo` prints, `pwd` → `/workspace`, and the trash + shims mounts work.

Rolled out to the live fleet (imagine, haseef, khitabik, monafasaty, tasibot).

## Known follow-ups (out of scope for this PR)

- `network=False` sandboxes still fail on `--unshare-net` loopback (`RTM_NEWADDR: No child processes`, a gVisor netlink limitation). No current agent uses `network=False`.
- Observability: `_exec_bash` returns bwrap's startup stderr as normal output, so sandbox-init failures log as `ok:true` — this is what kept the outage invisible. Worth surfacing non-zero bwrap exits as real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqxJMJQSAf8cgK13vMqWdW
